### PR TITLE
Fix Promise.all to ES6 Spec

### DIFF
--- a/src/zousan.js
+++ b/src/zousan.js
@@ -251,6 +251,9 @@
 
 			function rp(p,i)
 			{
+				if (typeof p.then !== "function") {
+					p = Zousan.resolve(p);
+				}
 				p.then(
 						function(yv) { results[i] = yv; rc++; if(rc == pa.length) retP.resolve(results); },
 						function(nv) { retP.reject(nv); }


### PR DESCRIPTION
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/all

Promise.all should take an iterable which can be a mixture of Objects and Promises, this PR wraps all non thenable items passed into Zousan.all in a Promise
