### PR TITLE
Proposed fix for Issue #7

### DIFF
--- a/src/zousan.js
+++ b/src/zousan.js
@@ -91,13 +91,27 @@
 			//  this.state = STATE_PENDING;	// Inital state (PENDING is undefined, so no need to actually have this assignment)
 			//this.c = [];			// clients added while pending.   <Since 1.0.2 this is lazy instantiation>
 
+			// If Zousan is called without "new", throw an error
+			if (!(this instanceof Zousan)) throw new TypeError("Zousan must be created with the new keyword");
+
 			// If a function was specified, call it back with the resolve/reject functions bound to this context
-			if(func)
+			if(typeof func === "function")
 			{
 				var me = this;
-				func(
-					function(arg) { me.resolve(arg) },	// the resolve function bound to this context.
-					function(arg) { me.reject(arg) })	// the reject function bound to this context
+				try
+				{
+					func(
+						function(arg) { me.resolve(arg) },	// the resolve function bound to this context.
+						function(arg) { me.reject(arg) })	// the reject function bound to this context
+				}
+				catch(e)
+				{
+					me.reject(e);
+				}
+			}
+			else if(arguments.length > 0) // If an argument was specified and it is not a function, throw an error
+			{
+				throw new TypeError("Promise resolver " + func + " is not a function");
 			}
 		}
 

--- a/src/zousan.js
+++ b/src/zousan.js
@@ -106,7 +106,7 @@
 				}
 				catch(e)
 				{
-					me.reject(e);
+					rejectWithErrorSuppression(me,e);
 				}
 			}
 			else if(arguments.length > 0) // If an argument was specified and it is not a function, throw an error
@@ -229,6 +229,15 @@
 
 			}; // END of prototype function list
 
+		function rejectWithErrorSuppression(p,reason)
+		{
+			var flag = Zousan.suppressUncaughtRejectionError; // Save the current state of the flag for suppressing uncaught rejection errors
+
+			Zousan.suppressUncaughtRejectionError = true;
+			p.reject(reason);
+			Zousan.suppressUncaughtRejectionError = flag;
+		}
+
 		function resolveClient(c,arg)
 		{
 			if(typeof c.y === "function")
@@ -262,7 +271,7 @@
 
 		Zousan.resolve = function(val) { var z = new Zousan(); z.resolve(val); return z; }
 
-		Zousan.reject = function(err) { var z = new Zousan(); z.reject(err); return z; }
+		Zousan.reject = function(err) { var z = new Zousan(); rejectWithErrorSuppression(z,err); return z; }
 
 		Zousan.all = function(pa)
 		{


### PR DESCRIPTION
I'd like to propose this as fix for Issue https://github.com/bluejava/zousan/issues/7

It will add these changes:

- Throw a TypeError if the constructor is called without `new`
- Catch errors in the Zousan resolver function
- Throw a TypeError if the constructor is called with an argument that is not a function
- Suppress the 'uncaught rejection' error message if the rejection happens in the constructor or in the class function `Zousan.resolve`
